### PR TITLE
Add Facebook-style login page example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # terraform-dev
+Example project with a simple Facebook-style login page built using HTML, CSS and JavaScript.
+Open `index.html` in a browser to view it.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Facebook Login Replica</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <div class="left-panel">
+      <h1>facebook</h1>
+      <p>Facebook te ayuda a comunicarte y compartir con las personas que forman parte de tu vida.</p>
+    </div>
+    <div class="right-panel">
+      <form id="login-form">
+        <input type="text" placeholder="Correo electrónico o número de teléfono" required>
+        <input type="password" placeholder="Contraseña" required>
+        <button type="submit">Iniciar sesión</button>
+        <a class="forgot" href="#">¿Olvidaste tu contraseña?</a>
+        <div class="divider"></div>
+        <button type="button" class="create-account">Crear cuenta nueva</button>
+      </form>
+      <p class="create-page"><strong>Crea una página</strong> para una celebridad, una marca o un negocio.</p>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,7 @@
+document.getElementById('login-form').addEventListener('submit', function (e) {
+  e.preventDefault();
+  const [emailInput, passwordInput] = this.querySelectorAll('input');
+  console.log('Email:', emailInput.value);
+  console.log('Password:', passwordInput.value);
+  alert('Inicio de sesión simulado.');
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,89 @@
+body {
+  background-color: #f0f2f5;
+  font-family: Helvetica, Arial, sans-serif;
+  margin: 0;
+}
+
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.left-panel {
+  margin-right: 60px;
+}
+
+.left-panel h1 {
+  color: #1877f2;
+  font-size: 4rem;
+  margin-bottom: 0.5rem;
+}
+
+.left-panel p {
+  font-size: 1.5rem;
+}
+
+.right-panel {
+  width: 396px;
+}
+
+form {
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1), 0 8px 16px rgba(0,0,0,0.1);
+  padding: 20px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+form input {
+  height: 52px;
+  padding: 0 16px;
+  margin-bottom: 12px;
+  border: 1px solid #dddfe2;
+  border-radius: 6px;
+  font-size: 17px;
+}
+
+form button[type="submit"] {
+  background-color: #1877f2;
+  border: none;
+  color: #fff;
+  font-size: 20px;
+  padding: 14px 0;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-bottom: 12px;
+}
+
+form .forgot {
+  text-align: center;
+  color: #1877f2;
+  text-decoration: none;
+  font-size: 14px;
+  margin-bottom: 16px;
+}
+
+.divider {
+  height: 1px;
+  background-color: #dadde1;
+  margin: 16px 0;
+}
+
+.create-account {
+  background-color: #42b72a;
+  border: none;
+  color: #fff;
+  font-size: 17px;
+  padding: 14px 0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.create-page {
+  text-align: center;
+  font-size: 14px;
+  margin-top: 28px;
+}


### PR DESCRIPTION
## Summary
- Add HTML, CSS, and JS files implementing a Facebook-like login screen
- Document the new example in the README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a756dec1288323a26b361c30298f1f